### PR TITLE
Update Octokit dependence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'http://rubygems.org'
 
 gem 'sinatra', '~> 2.0'
 gem 'jwt', '~> 2.1'
-gem 'octokit', '~> 4.0'
+gem 'octokit', '~> 4.25'
 gem 'dotenv'


### PR DESCRIPTION
a new version of Faraday release breaking Octokit, reference to https://github.com/octokit/octokit.rb/issues/1155